### PR TITLE
Fix/password

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/kert/config/SecurityConfig.java
+++ b/src/main/java/com/kert/config/SecurityConfig.java
@@ -1,0 +1,28 @@
+package com.kert.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    // api 테스트용 인증 비활성화 꼭 추후 수정할 것!!!
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+            .csrf(csrf -> csrf.disable())
+            .authorizeHttpRequests(authz -> authz
+                .anyRequest().permitAll()
+            );
+        return http.build();
+    }
+
+}

--- a/src/main/java/com/kert/controller/PasswordController.java
+++ b/src/main/java/com/kert/controller/PasswordController.java
@@ -1,23 +1,26 @@
 package com.kert.controller;
 
+import com.kert.dto.PasswordDTO;
 import com.kert.model.Password;
 import com.kert.service.PasswordService;
-import org.springframework.beans.factory.annotation.Autowired;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Optional;
 
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/passwords")
 public class PasswordController {
-
-    @Autowired
-    private PasswordService passwordService;
+    private final PasswordService passwordService;
 
     @PostMapping
-    public ResponseEntity<Password> createPassword(@RequestBody Password password) {
-        Password createdPassword = passwordService.createPassword(password.getUserId(), password.getHash());
+    public ResponseEntity<Password> createPassword(@Valid @RequestBody PasswordDTO passwordDTO) {
+        Password createdPassword = passwordService.createPassword(passwordDTO);
         return ResponseEntity.ok(createdPassword);
     }
 
@@ -27,15 +30,17 @@ public class PasswordController {
         return password.map(ResponseEntity::ok)
                 .orElse(ResponseEntity.notFound().build());
     }
+
     @PutMapping("/{user_id}")
-    public ResponseEntity<Password> updatePassword(@PathVariable("user_id") Long userId, @RequestBody Password password) {
-        Password updatedPassword = passwordService.updatePassword(userId, password.getHash());
+    public ResponseEntity<Password> updatePassword(@PathVariable("user_id") Long userId, @RequestBody PasswordDTO passwordDTO) {
+        Password updatedPassword = passwordService.updatePassword(userId, passwordDTO);
         if (updatedPassword != null) {
             return ResponseEntity.ok(updatedPassword);
         }
         return ResponseEntity.notFound().build();
     }
 
+    @Transactional
     @DeleteMapping("/{user_id}")
     public ResponseEntity<Void> deletePassword(@PathVariable("user_id") Long userId) {
         passwordService.deletePassword(userId);

--- a/src/main/java/com/kert/dto/PasswordDTO.java
+++ b/src/main/java/com/kert/dto/PasswordDTO.java
@@ -1,0 +1,19 @@
+package com.kert.dto;
+
+import lombok.Data;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class PasswordDTO {
+    private Long userId;
+
+    @NotBlank(message = "비밀번호는 필수 항목입니다.")
+    @Size(min = 8, message = "비밀번호는 8자 이상이어야 합니다.")
+    private String password;
+    private String oldPassword;
+}


### PR DESCRIPTION
## Description
Password 관련 API 세부 수정

## Changes
- Service: DI 명시적으로 변경, 패스워드 변경 로직에서 기존 비밀번호 검사하도록 변경
- Controller: 명시적인 DI, vaildation 추가
- DTO: 요청에서 평문 패스워드 받아서 넘겨주는 dto 계층 추가, validation을 위한 어노테이션 추가
- Spring security: config 추가, 의존성 gradle에 추가.

## etc
- spring security 설정에 테스트용으로 모든 요청에 대한 인증 비활성화 해둔 상태
- 예전에 받았던 리뷰인 Transactional 어노테이션에 대한 건데, 이번엔 정말 delete 요청이 안들어가서 넣었습니다.
- 노션에도 적어뒀습니다만, 스프링 시큐리티 적용하고 h2 콘솔이 안됩니다. 그래서 data.sql이 실행이 안되는거 같은데 api는 정상동작합니다.